### PR TITLE
Qanda photo upload jc

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -138,6 +138,7 @@ body {
   left: 15%;
   right: 15%;
   background-color: #EDEBE8;
+  overflow: scroll;
 }
 .interaction {
   display: flex;

--- a/server/routes/questions.js
+++ b/server/routes/questions.js
@@ -68,7 +68,6 @@ router.route('/:question_id/answers')
     })
     .catch((error) => {
       console.error('Answer not created. Error: ', error);
-      res.status(response.status);
       res.end();
     });
   });

--- a/src/QandA/components/AnswerItem.jsx
+++ b/src/QandA/components/AnswerItem.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Photos from './Photos.jsx';
 import moment from 'moment';
 import axios from 'axios';
+import _ from 'underscore';
 
 class AnswerItem extends React.Component {
   constructor(props) {
@@ -77,7 +78,7 @@ class AnswerItem extends React.Component {
           </div>
         </div>
       <div className="photo-details">
-        <Photos photos={this.props.answer.photos}/>
+        <Photos photos={_.pluck(this.props.answer.photos, 'url')}/>
       </div>
     </div>
   )

--- a/src/QandA/components/Photos.jsx
+++ b/src/QandA/components/Photos.jsx
@@ -6,7 +6,7 @@ const Photos = (props) => {
       <div className="photo-list">
         {props.photos.map((photo, i) => {
           return (
-            <img key={i} src={`${photo.url}`} />
+            <img key={i} src={`${photo}`} />
             )
         })}
       </div>

--- a/src/QandA/components/QuestionItem.jsx
+++ b/src/QandA/components/QuestionItem.jsx
@@ -50,7 +50,9 @@ class QuestionItem extends React.Component {
 
   closeModal() {
     this.setState({
-      show: false
+      show: false,
+      photoPreviews: [],
+      photoFiles: []
     });
   }
 
@@ -79,12 +81,12 @@ class QuestionItem extends React.Component {
   }
 
   updatePhotos(e) {
-    let uploads = [];
+    let previews = [];
     for (var i = 0; i < e.target.files.length; i ++) {
-      uploads.push(URL.createObjectURL(e.target.files[i]));
+      previews.push(URL.createObjectURL(e.target.files[i]));
     }
     this.setState({
-      photoPreviews: this.state.photoPreviews.concat(uploads)
+      photoPreviews: this.state.photoPreviews.concat(previews),
     });
   }
 
@@ -134,7 +136,7 @@ class QuestionItem extends React.Component {
 
   handleSubmit(e) {
     e.preventDefault();
-    const {name, email, answerBody} = this.state;
+    const {name, email, answerBody, photoPreviews} = this.state;
     let invalids = this.areInvalid(name, email, answerBody);
     if (invalids.length > 0) {
       let responseMessage = 'You must enter the following: ';
@@ -143,8 +145,9 @@ class QuestionItem extends React.Component {
       }
       alert(responseMessage);
     } else {
+      let data = new FormData();
       axios.post(`/api/qa/questions/${this.props.question.question_id}/answers`,
-      {body: answerBody, name: name, email: email, photos: []})
+      {body: answerBody, name: name, email: email, photos: photoPreviews})
       .then((data) => {
         this.setState({
           answered: this.state.answered + 1
@@ -159,7 +162,7 @@ class QuestionItem extends React.Component {
 
   updateHelpful() {
     if(!this.state.updatedHelpfulness) {
-      axios.put(`/qa/questions/${this.props.question.question_id}/helpful`)
+      axios.put(`/api/qa/questions/${this.props.question.question_id}/helpful`)
       .catch((error) => {
         console.error('Question not marked as helpful. Error: ', error);
       })

--- a/src/QandA/components/QuestionItem.jsx
+++ b/src/QandA/components/QuestionItem.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactModal from 'react-modal';
 import axios from 'axios';
 import AnswerList from './AnswerList.jsx';
+import Photos from './Photos.jsx';
 
 
 class QuestionItem extends React.Component {
@@ -14,7 +15,8 @@ class QuestionItem extends React.Component {
       name: '',
       email: '',
       answerBody: '',
-      answered: 0
+      answered: 0,
+      photoPreviews: []
     };
     this.updateHelpful = this.updateHelpful.bind(this);
     this.closeModal = this.closeModal.bind(this);
@@ -22,6 +24,7 @@ class QuestionItem extends React.Component {
     this.updateName = this.updateName.bind(this);
     this.updateEmail = this.updateEmail.bind(this);
     this.updateAnswer = this.updateAnswer.bind(this);
+    this.updatePhotos = this.updatePhotos.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
     this.validateEmail = this.validateEmail.bind(this);
   }
@@ -73,6 +76,60 @@ class QuestionItem extends React.Component {
     this.setState({
       answerBody: e.target.value
     });
+  }
+
+  updatePhotos(e) {
+    let uploads = [];
+    for (var i = 0; i < e.target.files.length; i ++) {
+      uploads.push(URL.createObjectURL(e.target.files[i]));
+    }
+    this.setState({
+      photoPreviews: this.state.photoPreviews.concat(uploads)
+    });
+  }
+
+  renderPhotos() {
+    const {photoPreviews} = this.state;
+    let shortenedPhotoList = [];
+    for (var i = 0; i < 5; i ++ ) {
+      if (photoPreviews[i]) {
+        shortenedPhotoList.push(photoPreviews[i]);
+      }
+    }
+
+    if (photoPreviews.length > 0) {
+      return (
+        <div>
+          <Photos photos={shortenedPhotoList} />
+        </div>
+      )
+    } else {
+      return (
+        <div></div>
+      )
+    }
+  }
+
+  renderPhotoInput() {
+    const {photoPreviews} = this.state;
+
+    if (photoPreviews.length < 5) {
+      return (
+        <div>
+          <input
+            type="file"
+            accept="image/png, image/jpeg"
+            ref="file"
+            multiple={true}
+            onChange={this.updatePhotos}
+            ></input>
+        </div>
+      )
+    } else {
+      return (
+        <div></div>
+      )
+    }
   }
 
   handleSubmit(e) {
@@ -138,24 +195,51 @@ class QuestionItem extends React.Component {
                     <label>
                       Nickname:
                       <br></br>
-                      <input maxLength="60" type="text" placeholder="Example: jack543" onChange={this.updateName}></input>
+                      <input
+                      maxLength="60"
+                      type="text"
+                      placeholder="Example: jack543"
+                      onChange={this.updateName}></input>
                       <br></br>
                     </label>
                     <p>For privacy reasons, do not use your full name or email address</p>
                     <label>
                       Email:
                       <br></br>
-                      <input maxLength="60" type="email" placeholder="jack@email.com" onChange={this.updateEmail}></input>
+                      <input
+                      maxLength="60"
+                      type="email"
+                      placeholder="jack@email.com"
+                      onChange={this.updateEmail}></input>
                       <p>For authentications reasons, you will not be emailed.</p>
                     </label>
                     <br></br>
                     <label>
                       Answer:
                       <br></br>
-                      <textarea maxLength="1000" placeholder="Answer" onChange={this.updateAnswer}></textarea>
+                      <textarea
+                      maxLength="1000"
+                      placeholder="Answer"
+                      onChange={this.updateAnswer}></textarea>
                     </label>
                     <br></br>
-                    <button type="submit" onClick={this.handleSubmit}>Submit Answer!</button>
+                    <label>
+                      Add photos
+                      <br></br>
+                      {this.renderPhotos()}
+                      {this.renderPhotoInput()}
+                      {/* <input
+                      type="file"
+                      accept="image/png, image/jpeg"
+                      ref="file"
+                      multiple={true}
+                      onChange={this.updatePhotos}
+                      ></input> */}
+                    </label>
+                    <br></br>
+                    <button
+                    type="submit"
+                    onClick={this.handleSubmit}>Submit Answer!</button>
                   </form>
                 </div>
               </ReactModal>


### PR DESCRIPTION
### Styles: 
Changing photo preview and answer photos to scroll when they don't fit in container div.

### Questions.js
Removing passing of response status, as it breaks when there is an error. No need to error when trying to pass along information **about** an error. 

### AnswerItem.jsx and Photos.jsx
Only passing array of URLs to Photos.jsx to align with how we want to re-use the components.
Previously we were passing an array of all information about the photos, and accessing the url property within Photos.jsx. The array of photos passed from the QuestionItem.jsx component doesn't have this property, though. To align the arrays, we are now only passing in the urls directly to the Photos component. This required _.plucking them in the Answer Item component.

### QuestionItem.jsx
Importing Photos.jsx to keep things DRY (and yes, I know that's a bit ironic considering the rest of this file. I'll DRY it up later).
Added in logic to remove added photos from state upon leaving 'add answer' modal. Added in logic to keep added photos in state. Added in logic to only show "Add Files" button if there were fewer than 5 photos added, and to only preview 5 photos if the user selected more than that from the file selector, as well as only uploading the first 5 photos selected. 